### PR TITLE
Added swap file creation code before compiling OpenCV

### DIFF
--- a/Software/Image_processing/VCS-1/install_opencv4_VCS-1.sh
+++ b/Software/Image_processing/VCS-1/install_opencv4_VCS-1.sh
@@ -32,6 +32,11 @@ cd opencv-$VERSION
 mkdir -p build
 cd build
 
+sudo dd if=/dev/zero of=/swapfile bs=64M count=16
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+
 echo "Compiling OpenCV $VERSION ... this will take several minutes..."
 cmake -D CMAKE_BUILD_TYPE=RELEASE \
 	-D CMAKE_INSTALL_PREFIX=/usr/local \
@@ -55,6 +60,10 @@ echo "Compilation has started ..."
 make -j4
 echo "Installing OpenCV $VERSION ..."
 sudo make install
+
+sudo swapoff /swapfile
+sudo rm /swapfile
+
 sudo ldconfig
 source $HOME/.bashrc
 echo "Installation complete"


### PR DESCRIPTION
For the OpenCV version 4.12 (and possibly up) installing errors up as the 2gb of VCS-1 ram quickly fills up.
I have added few lines to create 1gb swap file, and remove it once compile and installation is complete.
With this changes scripts installs OpenCV sucessfully.